### PR TITLE
改变变量名，方便数据集更换

### DIFF
--- a/GraphSAGE_pyg.ipynb
+++ b/GraphSAGE_pyg.ipynb
@@ -24,10 +24,10 @@
     }
    ],
    "source": [
-    "dataset_cora = Planetoid(root='./cora/', name='Cora')\n",
+    "dataset = Planetoid(root='./cora/', name='Cora')\n",
     "# dataset = Planetoid(root='./citeseer',name='Citeseer')\n",
     "# dataset = Planetoid(root='./pubmed/',name='Pubmed')\n",
-    "print(dataset_cora)"
+    "print(dataset)"
    ]
   },
   {
@@ -52,8 +52,8 @@
     "class Net(nn.Module):\n",
     "    def __init__(self):\n",
     "        super(Net, self).__init__()\n",
-    "        self.conv1 = SAGEConv(dataset_cora.num_node_features, 16)\n",
-    "        self.conv2 = SAGEConv(16, dataset_cora.num_classes)\n",
+    "        self.conv1 = SAGEConv(dataset.num_node_features, 16)\n",
+    "        self.conv2 = SAGEConv(16, dataset.num_classes)\n",
     "\n",
     "    def forward(self, data):\n",
     "        x, edge_index = data.x, data.edge_index\n",


### PR DESCRIPTION
将dataset_cora改成dataset，方便后续训练citeseer和pubmed数据集时，无需更改模型内部（class Net）的代码，只需要取消数据集下载的注释